### PR TITLE
fix multiple urls display and copypaste typo

### DIFF
--- a/service/config.yaml
+++ b/service/config.yaml
@@ -47,7 +47,7 @@ categories:
           - растпобеда.рф
       - name: Nix
         items:
-          - растпобеда.рф
+          - никспобеда.рф
       - name: Scheme
         items:
           - схемапобеда.рф

--- a/service/template.md
+++ b/service/template.md
@@ -27,11 +27,20 @@
             {{- else if not $availability.Successful }}
                 {{- $status = "(неуспешный статус код)" }}
             {{- end}}
-- {{$domain.Name}} — [{{index $domain.Items 0}}](https://{{index $domain.Items 0}}) {{$status}}
+- {{$domain.Name}} — [{{$url}}](https://{{$url}}) {{$status}}
         {{- else if gt (len $domain.Items) 1 }}
 - {{$domain.Name}}:
             {{- range $url := $domain.Items }}
-    - [{{index $domain.Items 0}}](https://{{index $domain.Items 0}})
+                {{- $availability := index $config.Availability $url }}
+                {{- $status := "" }}
+                {{- if not $availability.Resolved }}
+                    {{- $status = "(домен недоступен)" }}
+                {{- else if not $availability.Reachable }}
+                    {{- $status = "(сервер недоступен)" }}
+                {{- else if not $availability.Successful }}
+                    {{- $status = "(неуспешный статус код)" }}
+                {{- end}}
+    - [{{$url}}](https://{{$url}}) {{$status}}
             {{- end }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
фиксит отображение статуса и отбражение правильных ссылок в случае если их несколько
и фиксит ссылку для никса

дифф ридми:
```diff
diff --git a/README.md b/README.md
index 661a955..b98c327 100644
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@
 - Kotlin — [котлинпобеда.рф](https://котлинпобеда.рф) (домен недоступен)
 - JavaScript — [жспобеда.рф](https://жспобеда.рф) 
 - TypeScript:
-    - [тспобеда.рф](https://тспобеда.рф)
-    - [тспобеда.рф](https://тспобеда.рф)
+    - [тспобеда.рф](https://тспобеда.рф) (домен недоступен)
+    - [тайпскриптпобеда.рф](https://тайпскриптпобеда.рф) 
 - Lua — [луапобеда.рф](https://луапобеда.рф) (неуспешный статус код)
 - Pascal — [паскальпобеда.рф](https://паскальпобеда.рф) 
 - HTML — [хтмлпобеда.рф](https://хтмлпобеда.рф) 
 - Elixir — [эликсирпобеда.рф](https://эликсирпобеда.рф) (сервер недоступен)
 - Python — [питонпобеда.рф](https://питонпобеда.рф) 
 - Rust — [растпобеда.рф](https://растпобеда.рф) 
-- Nix — [растпобеда.рф](https://растпобеда.рф) 
+- Nix — [никспобеда.рф](https://никспобеда.рф) (домен недоступен)
 - Scheme — [схемапобеда.рф](https://схемапобеда.рф) 
 - V — [випобеда.рф](https://випобеда.рф) 
 ```